### PR TITLE
Feature definedterm json ld

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,19 @@ New FAQ entries contain this front matter section:
 
 ```
 ---
-title:
+question:
 weight: 999
 ---
 ```
 
-- Add the question to the `title` field, without surrounding quotes.
+- Add the question to the `question` field, without surrounding quotes.
 - The `weight` entry specifies the sequence of FAQ entries. In other words, FAQ entries are sorted by weight in ascending order. Typically you would set this to the count of existing FAQ files (including the new one). If you want to move that item to a higher position, you would need to change the weights of all entries that shall appear after the new one. 
 - Write the answer below the front matter. You can use Markdown formatting here.
 
 Example:
 ```
 ---
-title: Pepsi or Coke?
+question: Pepsi or Coke?
 weight: 8
 ---
 It depends.

--- a/README.md
+++ b/README.md
@@ -59,19 +59,19 @@ New FAQ entries contain this front matter section:
 
 ```
 ---
-question:
+title:
 weight: 999
 ---
 ```
 
-- Add the question to the `question` field, without surrounding quotes.
+- Add the question to the `title` field, without surrounding quotes.
 - The `weight` entry specifies the sequence of FAQ entries. In other words, FAQ entries are sorted by weight in ascending order. Typically you would set this to the count of existing FAQ files (including the new one). If you want to move that item to a higher position, you would need to change the weights of all entries that shall appear after the new one. 
 - Write the answer below the front matter. You can use Markdown formatting here.
 
 Example:
 ```
 ---
-question: Pepsi or Coke?
+title: Pepsi or Coke?
 weight: 8
 ---
 It depends.

--- a/archetypes/faq.md
+++ b/archetypes/faq.md
@@ -1,5 +1,5 @@
 ---
-question:
+title:
 weight: 999
 ---
 

--- a/archetypes/glossary.md
+++ b/archetypes/glossary.md
@@ -1,10 +1,14 @@
 ---
-title: A title
-description: A new entry to the glossary
+title: 
+description: 
 tags:
-  - fundamental
+  - 
 ---
 
-This is a new entry to the glossary. Edit and test it, then set `draft` to `false` for publishing the entry.
+<!-- Fill the metadata:
+title = glossary term
+description = a *short* description
+tags: (optional) one or more tags
 
+Write a long description in the document body. -->
 

--- a/themes/godocs-3/layouts/_default/baseof.html
+++ b/themes/godocs-3/layouts/_default/baseof.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+
 <head>
 	{{- partial "head.html" . -}}
+	{{ partial "site_schema.html" . }}
 	{{- partialCached "style.html" . -}}
 </head>
 

--- a/themes/godocs-3/layouts/partials/site_schema.html
+++ b/themes/godocs-3/layouts/partials/site_schema.html
@@ -1,0 +1,66 @@
+{{ if .IsHome -}}
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "WebSite",
+    "name": "{{ .Site.Title }}",
+    "url": "{{ .Site.BaseURL }}",
+    "description": "{{ .Site.Params.description }}",
+    "thumbnailUrl": "{{ .Site.Params.Logo | absURL }}",
+    "license": "{{ .Site.Params.Copyright }}"
+}
+</script>
+{{ else if .IsPage }}
+{{ $author := or (.Params.author) (.Site.Author.name) }}
+{{ $org_name := .Site.Title }}
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "BlogPosting",
+    "articleSection": "{{ .Section }}",
+    "name": "{{ .Title | safeJS }}",
+    "headline": "{{ .Title | safeJS }}",
+    "alternativeHeadline": "{{ .Params.lead }}",
+    "description": "{{ if .Description }}{{ .Description | safeJS }}{{ else }}{{if .IsPage}}{{ .Summary  }}{{ end }}{{ end }}",
+    "inLanguage": {{ .Site.LanguageCode | default "en-us" }},
+    "isFamilyFriendly": "true",
+    "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "{{ .Permalink }}"
+    },
+    "author" : {
+        "@type": "Person",
+        "name": "{{ $author }}"
+    },
+    "creator" : {
+        "@type": "Person",
+        "name": "{{ $author }}"
+    },
+    "accountablePerson" : {
+        "@type": "Person",
+        "name": "{{ $author }}"
+    },
+    "copyrightHolder" : "{{ $org_name }}",
+    "copyrightYear" : "{{ .Date.Format "2006" }}",
+    "dateCreated": "{{ .Date.Format "2006-01-02T15:04:05.00Z" | safeHTML }}",
+    "datePublished": "{{ .PublishDate.Format "2006-01-02T15:04:05.00Z" | safeHTML }}",
+    "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05.00Z" | safeHTML }}",
+    "publisher":{
+        "@type":"Organization",
+        "name": {{ $org_name }},
+        "url": {{ .Site.BaseURL }},
+        "logo": {
+            "@type": "ImageObject",
+            "url": "{{ .Site.Params.logo | absURL }}",
+            "width":"32",
+            "height":"32"
+        }
+    },
+    "image": {{ if .Params.images }}[{{ range $i, $e := .Params.images }}{{ if $i }}, {{ end }}{{ $e | absURL }}{{ end }}]{{ else}}{{.Site.Params.logo | absURL }}{{ end }},
+    "url" : "{{ .Permalink }}",
+    "wordCount" : "{{ .WordCount }}",
+    "genre" : [ {{ range $index, $tag := .Params.tags }}{{ if $index }}, {{ end }}"{{ $tag }}" {{ end }}],
+    "keywords" : [ {{ range $index, $keyword := .Params.keywords }}{{ if $index }}, {{ end }}"{{ $keyword }}" {{ end }}]
+}
+</script>
+{{ end }}

--- a/themes/godocs-3/layouts/partials/site_schema.html
+++ b/themes/godocs-3/layouts/partials/site_schema.html
@@ -18,7 +18,7 @@
     "@context": "http://schema.org",
     "@type": "BlogPosting",
     "articleSection": "{{ .Section }}",
-    "name": "{{ .Title | safeJS }}",
+    "name": "{{ (or .Params.question .Params.title .Title) | safeJS }}",
     "headline": "{{ .Title | safeJS }}",
     "alternativeHeadline": "{{ .Params.lead }}",
     "description": "{{ if .Description }}{{ .Description | safeJS }}{{ else }}{{if .IsPage}}{{ .Summary  }}{{ end }}{{ end }}",


### PR DESCRIPTION
New Feature: generate JSON-LD data for page attributes like name, definition etc.

Implemented using site_schema.html from the article [Add Structure Data JSON-LD in Hugo Website Pages - Coding N Concepts](https://codingnconcepts.com/hugo/structure-data-json-ld-hugo/).

This template is used without modifications and applies to the home page and to standard pages (esp. no list pages, so the glossary accordion page does not carry JSON-LD information, only the individual pages do.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201900036947152