### PR TITLE
feat: disable call_to_action

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -139,14 +139,14 @@ weight = 1
 
 # call to action
 [Languages.en.call_to_action]
-enable = true
+enable = false
 title = "Still Didn't Find Your Answer?"
 image = "images/cta-illustration.jpg"
 content = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <br> nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam"
 
   # call to action button
   [Languages.en.call_to_action.button]
-  enable = true
+  enable = false
   label = "Submit a ticket"
   link = "contact"
 


### PR DESCRIPTION
Remove support block from the footer of all content pages. Resolves #41