### PR TITLE
feat: add new glossary items(without full definitions)

### DIFF
--- a/content/glossary/chiba-clonk.md
+++ b/content/glossary/chiba-clonk.md
@@ -1,0 +1,8 @@
+---
+title: Chiba Clonk
+description: A Laconic-centric version of Ethermint that supports EVM accounts and provides a naming service
+tags:
+  - fundamental
+---
+
+Chiba Clonk is a fork of [Ethermint]({{< relref "ethermint" >}}) that...

--- a/content/glossary/cosmjs.md
+++ b/content/glossary/cosmjs.md
@@ -1,0 +1,9 @@
+---
+title: CosmJS
+description: CosmJS is the Swiss Army knife to power JavaScript based client solutions ranging from Web apps/explorers over browser extensions to server-side clients like faucets/scrapers in the Cosmos ecosystem
+tags:
+  - fundamental
+  - cosmos
+---
+
+CosmJS is...

--- a/content/glossary/dapp-developer.md
+++ b/content/glossary/dapp-developer.md
@@ -1,0 +1,8 @@
+---
+title: Dapp Developer
+description: A developer who is building a decentralized application
+tags:
+  - fundamental
+---
+
+(This is the same as the DApp Operator definition -- let's clarify the difference between the two before adding this)A Dapp Developer takes care of deploying and operating a [Decentralized App]({{< relref "dapp" >}}).

--- a/content/glossary/ethermint.md
+++ b/content/glossary/ethermint.md
@@ -1,0 +1,10 @@
+---
+title: Ethermint
+description: Ethermint is a scalable, high-throughput Proof-of-Stake blockchain that is fully compatible and interoperable with Ethereum
+tags:
+  - fundamental
+---
+
+Ethermint is a scalable, high-throughput Proof-of-Stake blockchain that is fully compatible and interoperable with Ethereum. It is built using the Cosmos SDK which runs on top of Tendermint Core consensus engine.
+
+Ethermint allows for running vanilla Ethereum as a Cosmos application-specific blockchain. This allows developers to have all the desired features of Ethereum, while at the same time, benefit from Tendermint’s PoS implementation. Also, because it is built on top of the Cosmos SDK, it will be able to exchange value with the rest of the Cosmos Ecosystem through the Inter Blockchain Communication Protocol (IBC).

--- a/content/glossary/incentivized-testnet.md
+++ b/content/glossary/incentivized-testnet.md
@@ -1,0 +1,8 @@
+---
+title: Incentivized Testnet
+description: Will incentivize Watcher Publishers and Service Providers to participate in the Laconic Network in exchange for LNT
+tags:
+  - fundamental
+---
+
+The Incentivized Testnet is...

--- a/content/glossary/laconic-chain.md
+++ b/content/glossary/laconic-chain.md
@@ -1,0 +1,8 @@
+---
+title: Laconic Chain
+description: A sovereign chain built on top of the Cosmos ecosystem that is secured by the Laconic Network Token(LNT)
+tags:
+  - fundamental
+---
+
+The Laconic Chain is...

--- a/content/glossary/laconic-sdk.md
+++ b/content/glossary/laconic-sdk.md
@@ -1,0 +1,8 @@
+---
+title: Laconic SDK
+description: A toolkit for interfacing with the Laconic Stack
+tags:
+  - fundamental
+---
+
+The Laconic SDK is a toolkit comprised of...

--- a/content/glossary/libp2p.md
+++ b/content/glossary/libp2p.md
@@ -1,0 +1,12 @@
+---
+title: libp2p
+description: A modular system of protocols, specifications and libraries that enable the development of peer-to-peer network applications
+tags:
+  - fundamental
+---
+
+`libp2p` is a set of network protocols of various levels and purposes.
+
+`libp2p` provides a transport layer, which handles the transmission of data between peers on a network.
+
+(Add content about Identity, Security, Peer Routing, Content Discovery and Message Pub/Sub)

--- a/content/glossary/naming-service.md
+++ b/content/glossary/naming-service.md
@@ -1,0 +1,8 @@
+---
+title: Naming Service (DXNS)
+description: A Naming Service provides a mechanism for giving names to objects so you can retrieve and use those objects without knowing the location of the object
+tags:
+  - fundamental
+---
+
+The DXOS Naming Service (DXNS) is a custom blockchain built using [Cosmos SDK]({{< relref "cosmos-sdk" >}}).

--- a/content/glossary/watcher-publisher.md
+++ b/content/glossary/watcher-publisher.md
@@ -5,4 +5,4 @@ tags:
   - fundamental
 ---
 
-A Watcher Publisher writes [Watchers]({{< relref "watcher" >}}) to be put up for auction on the Laconic Network for [Service Providers]({{< relref "service-provider" >}}) to bid for the right to run them/
+A Watcher Publisher writes [Watchers]({{< relref "watcher" >}}) to be put up for auction on the Laconic Network for [Service Providers]({{< relref "service-provider" >}}) to bid for the right to run them.

--- a/content/glossary/watcher-publisher.md
+++ b/content/glossary/watcher-publisher.md
@@ -1,0 +1,8 @@
+---
+title: Watcher Publisher
+description: A developer or party who writes Watchers to be used on the Laconic Network
+tags:
+  - fundamental
+---
+
+A Watcher Publisher writes [Watchers]({{< relref "watcher" >}}) to be put up for auction on the Laconic Network for [Service Providers]({{< relref "service-provider" >}}) to bid for the right to run them/


### PR DESCRIPTION
# Description

Adding new glossary definition files for these items:
- CosmJS
- Laconic Chain 
- Ethermint
- Chiba Clonk 
- Incentivized Testnet
- Dapp Developer -- same as Dapp Operator?
- Watcher Publisher
- Naming Service (DXNS)
- ~~Service Provider~~ already added
- libp2p -- we mention devp2p, so should mention libp2p

In most cases I've only added some very basic `descriptions`, but the full definitions for these will have to be fleshed out more

## Link to issue

https://github.com/LaconicNetwork/Laconic-Documentation/issues/48
